### PR TITLE
Recommend using constructor injection for parameters instead of ParameterBagInterface

### DIFF
--- a/docs/docs/03_API/2_Configuration.md
+++ b/docs/docs/03_API/2_Configuration.md
@@ -51,22 +51,31 @@ your *docker-compose.yml* file.
 
 ### Parameters
 
-If you need the value of an environment variable in your code, use the Symfony parameters.
+If you need the value of an environment variable in your code, use the Symfony parameters and dependency injection
+to inject the parameter into your service.
 
 For instance:
 
 ```yaml title="src/api/config/services.yaml"
 parameters:
-    app.foo: : '%env(FOO)%'
+    app.foo: '%env(FOO)%'
+    
+services:
+    App\UseCase\MyUseCase:
+        arguments:
+            $foo: %app.foo%
 ```
 
 ```php
-# A class.
-private string $foo;
+namespace App\UseCase;
 
-public function __construct(
-    ParameterBagInterface $parameters
-) {
-    $this->foo = $parameters->get('app.foo');
+class MyUseCase {
+    private string $foo;
+
+    public function __construct(
+        string $foo
+    ) {
+        $this->foo = $foo;
+    }
 }
 ```


### PR DESCRIPTION


Symfony 4.1 introduced a way to inject the ParameterBagInterface directly by autowiring.
See: https://symfony.com/blog/new-in-symfony-4-1-getting-container-parameters-as-a-service

However, I believe this is an anti-pattern (just like injecting the container in a service is an anti-pattern).
This makes your services dependent on "all" the parameters of the application.

Also, it "hides" the parameters used by the service (you cannot tell what parameters are needed by the constructor)

Finally, it makes the code harder to unit test in case you want to.

We should instead recommend injecting the parameters into the constructor of the service using classic dependency injection.

It requires a 3 lines of code in services.yaml, but hopefully, makes the code easier to read on the service side (and less dependant on Symfony)