### PR TITLE
Making sure the tmp file is removed.

### DIFF
--- a/docs/docs/09_Files/2_Temporary Files.md
+++ b/docs/docs/09_Files/2_Temporary Files.md
@@ -16,11 +16,16 @@ use function Safe\unlink;
 
 protected function createResponseWithXLSXAttachment(string $filename, Xlsx $xlsx): Response
 {
-    $tmpFilename = Uuid::uuid4()->toString() . '.xlsx';
-    $xlsx->save($tmpFilename);
-    $fileContent = file_get_contents($tmpFilename); // Get the file content.
-    unlink($tmpFilename); // Delete the file.
-
+    try {
+        $tmpFilename = Uuid::uuid4()->toString() . '.xlsx';
+        $xlsx->save($tmpFilename);
+        $fileContent = file_get_contents($tmpFilename); // Get the file content.
+    } finally {
+        if (file_exists($tmpFilename)) {
+            unlink($tmpFilename); // Delete the file.
+        }
+    }
+    
     return $this->createResponseWithAttachment(
         $filename,
         $fileContent


### PR DESCRIPTION
If an exception arise, the tmp file might not be removed. By using a finally block, we make sure we can remove this file, whatever happens.