### PR TITLE
fix-docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - --api.insecure=true
     labels:
       - traefik.enable=true
-      - traefik.http.routers.traefik_dashboard_router.rule=Host(`traefik.$DOMAIN`)
+      - traefik.http.routers.traefik_dashboard_router.rule=Host(`traefik.${DOMAIN}`)
       - traefik.http.routers.traefik_dashboard_router.service=traefik_dashboard_service
       - traefik.http.services.traefik_dashboard_service.loadbalancer.server.port=8080
     ports:
@@ -24,7 +24,7 @@ services:
     image: thecodingmachine/nodejs:14
     labels:
       - traefik.enable=true
-      - traefik.http.routers.webapp_router.rule=Host(`$DOMAIN`)
+      - traefik.http.routers.webapp_router.rule=Host(`${DOMAIN}`)
       - traefik.http.routers.webapp_router.service=webapp_service
       - traefik.http.services.webapp_service.loadbalancer.server.port=3000
     expose:
@@ -45,17 +45,17 @@ services:
       HOST: "0.0.0.0"
       # Nuxt.js
       # ---------------------
-      APP_NAME: "$APP_NAME"
+      APP_NAME: "${APP_NAME}"
       # API.
-      API_URL: "http://$API_SUBDOMAIN.$DOMAIN/"
+      API_URL: "http://${API_SUBDOMAIN}.${DOMAIN}/"
       # GraphQL.
-      GRAPHQL_URL: "http://$API_SUBDOMAIN.$DOMAIN/graphql"
+      GRAPHQL_URL: "http://${API_SUBDOMAIN}.${DOMAIN}/graphql"
       # Public storage.
       # Access to these files is done via URLs created using:
-      # "$PUBLIC_STORAGE_URL" + folder + "/" + filename.
-      PUBLIC_STORAGE_URL: "http://$STORAGE_SUBDOMAIN.$DOMAIN/public/"
+      # "PUBLIC_STORAGE_URL" + folder + "/" + filename.
+      PUBLIC_STORAGE_URL: "http://${STORAGE_SUBDOMAIN}.${DOMAIN}/public/"
       # i18n.
-      DEFAULT_LOCALE: "$DEFAULT_LOCALE"
+      DEFAULT_LOCALE: "${DEFAULT_LOCALE}"
       # LogRocket.
       # LOGROCKET_ID
       # LOGROCKET_DEV_MODE_ALLOWED
@@ -66,7 +66,7 @@ services:
     image: thecodingmachine/php:7.4-v4-apache
     labels:
       - traefik.enable=true
-      - traefik.http.routers.api_router.rule=Host(`$API_SUBDOMAIN.$DOMAIN`)
+      - traefik.http.routers.api_router.rule=Host(`${API_SUBDOMAIN}.${DOMAIN}`)
     environment:
       # Docker image.
       # ---------------------
@@ -82,40 +82,40 @@ services:
       STARTUP_COMMAND_4: "php bin/console app:init-storage:s3"
       # Symfony.
       # ---------------------
-      APP_NAME: "$APP_NAME"
+      APP_NAME: "${APP_NAME}"
       APP_ENV: "dev"
       APP_DEBUG: "1"
       # Note: in your remote environments, make sure you do not change
       # the value of APP_SECRET between deployments. Otherwise, password
       # verification will not work anymore.
-      APP_SECRET: "$APP_SECRET"
-      COOKIE_DOMAIN: ".$DOMAIN" # The "." is important here; it tells that the cookie is available for $DOMAIN and its subdomains.
+      APP_SECRET: "${APP_SECRET}"
+      COOKIE_DOMAIN: ".${DOMAIN}" # The "." is important here; it tells that the cookie is available for $DOMAIN and its subdomains.
       # CORS.
-      CORS_ALLOW_ORIGIN: "http://$DOMAIN" # Never use "*": https://stackoverflow.com/questions/52060784/graphql-and-csrf-protection.
+      CORS_ALLOW_ORIGIN: "http://${DOMAIN}" # Never use "*": https://stackoverflow.com/questions/52060784/graphql-and-csrf-protection.
       # Logging.
       MONOLOG_LOGGING_PATH: "php://stderr"
       # Database.
-      DATABASE_URL: "mysql://$MYSQL_USER:$MYSQL_PASSWORD@mysql:3306/$MYSQL_DATABASE?server_version=8.0"
-      TESTS_DATABASE_URL: "mysql://$MYSQL_USER:$MYSQL_PASSWORD@mysql_tests:3306/$MYSQL_DATABASE?server_version=8.0"
+      DATABASE_URL: "mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql:3306/${MYSQL_DATABASE}?server_version=8.0"
+      TESTS_DATABASE_URL: "mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql_tests:3306/${MYSQL_DATABASE}?server_version=8.0"
       # Messenger.
-      MESSENGER_TRANSPORT_DSN: "redis://$REDIS_PASSWORD@redis:6379/messages"
+      MESSENGER_TRANSPORT_DSN: "redis://${REDIS_PASSWORD}@redis:6379/messages"
       # Storage.
       # Note: in other environments, the following values/variables might differ according
       # to your storage sources (see src/api/config/packages/flysystem.yaml).
       STORAGE_PUBLIC_SOURCE: "public.storage.s3"
       STORAGE_PRIVATE_SOURCE: "private.storage.s3"
       STORAGE_ENDPOINT: "http://minio:9000"
-      STORAGE_PUBLIC_BUCKET: "$STORAGE_PUBLIC_BUCKET"
-      STORAGE_PRIVATE_BUCKET: "$STORAGE_PRIVATE_BUCKET"
-      STORAGE_ACCESS_KEY: "$STORAGE_ACCESS_KEY"
-      STORAGE_SECRET_KEY: "$STORAGE_SECRET_KEY"
+      STORAGE_PUBLIC_BUCKET: "${STORAGE_PUBLIC_BUCKET}"
+      STORAGE_PRIVATE_BUCKET: "${STORAGE_PRIVATE_BUCKET}"
+      STORAGE_ACCESS_KEY: "${STORAGE_ACCESS_KEY}"
+      STORAGE_SECRET_KEY: "${STORAGE_SECRET_KEY}"
       # i18n.
-      DEFAULT_LOCALE: "$DEFAULT_LOCALE"
+      DEFAULT_LOCALE: "${DEFAULT_LOCALE}"
       # Mailer.
       MAILER_DSN: "smtp://null:null@mailhog:1025"
-      MAIL_FROM_ADDRESS: "no-reply@$DOMAIN"
+      MAIL_FROM_ADDRESS: "no-reply@${DOMAIN}"
       MAIL_FROM_NAME: "$APP_NAME"
-      MAIL_WEBAPP_URL: "http://$DOMAIN/"
+      MAIL_WEBAPP_URL: "http://${DOMAIN}/"
       MAIL_WEBAPP_UPDATE_PASSWORD_ROUTE_FORMAT: "%s/update-password/%s/%s" # {locale}/update-password/{resetPasswordTokenId}/{plainToken}
     volumes:
       - ./src/api:/var/www/html
@@ -124,17 +124,17 @@ services:
         aliases:
           # Required so that the web application is able to call the same endpoint
           # from both the browser and the server.
-          - "$API_SUBDOMAIN.$DOMAIN"
+          - "${API_SUBDOMAIN}.${DOMAIN}"
 
   # For business data and user sessions.
   mysql:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_ROOT_PASSWORD: "$MYSQL_ROOT_PASSWORD"
-      MYSQL_DATABASE: "$MYSQL_DATABASE"
-      MYSQL_USER: "$MYSQL_USER"
-      MYSQL_PASSWORD: "$MYSQL_PASSWORD"
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${MYSQL_DATABASE}"
+      MYSQL_USER: "${MYSQL_USER}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
     volumes:
       - mysql_data:/var/lib/mysql
 
@@ -143,10 +143,10 @@ services:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_ROOT_PASSWORD: "$MYSQL_ROOT_PASSWORD"
-      MYSQL_DATABASE: "$MYSQL_DATABASE"
-      MYSQL_USER: "$MYSQL_USER"
-      MYSQL_PASSWORD: "$MYSQL_PASSWORD"
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${MYSQL_DATABASE}"
+      MYSQL_USER: "${MYSQL_USER}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
     tmpfs:
       - /var/lib/mysql
 
@@ -157,14 +157,14 @@ services:
       - traefik.http.routers.phpmyadmin_router.rule=Host(`phpmyadmin.$DOMAIN`)
     environment:
       PMA_HOSTS: "mysql, mysql_tests"
-      PMA_USER: "$MYSQL_USER"
-      PMA_PASSWORD: "$MYSQL_PASSWORD"
+      PMA_USER: "${MYSQL_USER}"
+      PMA_PASSWORD: "${MYSQL_PASSWORD}"
 
   # For asynchronous tasks and emails.
   redis:
     image: bitnami/redis:6.0
     environment:
-      REDIS_PASSWORD: "$REDIS_PASSWORD"
+      REDIS_PASSWORD: "${REDIS_PASSWORD}"
     tmpfs:
       - /bitnami/redis/data
 
@@ -173,7 +173,7 @@ services:
     image: mailhog/mailhog:latest
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mailhog_router.rule=Host(`mailhog.$DOMAIN`)
+      - traefik.http.routers.mailhog_router.rule=Host(`mailhog.${DOMAIN}`)
       - traefik.http.routers.mailhog_router.service=mailhog_service
       - traefik.http.services.mailhog_service.loadbalancer.server.port=8025
 
@@ -183,12 +183,12 @@ services:
     command: server /data
     labels:
       - traefik.enable=true
-      - traefik.http.routers.minio_router.rule=Host(`$STORAGE_SUBDOMAIN.$DOMAIN`)
+      - traefik.http.routers.minio_router.rule=Host(`${STORAGE_SUBDOMAIN}.${DOMAIN}`)
       - traefik.http.routers.minio_router.service=minio_service
       - traefik.http.services.minio_service.loadbalancer.server.port=9000
     environment:
-      MINIO_ACCESS_KEY: "$STORAGE_ACCESS_KEY"
-      MINIO_SECRET_KEY: "$STORAGE_SECRET_KEY"
+      MINIO_ACCESS_KEY: "${STORAGE_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${STORAGE_SECRET_KEY}"
     volumes:
       - minio_data:/data
 


### PR DESCRIPTION
# situation
when I try to run the boilerplate using `make up` command after copying the .env.dist to .env using `cp .env.dist .env` it outputs the followings 
```
WARN[0000] The PUBLIC_STORAGE_URL variable is not set. Defaulting to a blank string. 
WARN[0000] The MYSQL_DATABASE?server_version=8.0"
      TESTS_DATABASE_URL: "mysql://$MYSQL_USER:$MYSQL_PASSWORD@mysql_tests:3306/$MYSQL_DATABASE?server_version=8.0"
      # Messenger.
      MESSENGER_TRANSPORT_DSN: "redis://$REDIS_PASSWORD@redis:6379/messages"
      # Storage.
      # Note: in other environments, the following values/variables might differ according
      # to your storage sources (see src/api/config/packages/flysystem.yaml).
      STORAGE_PUBLIC_SOURCE: "public.storage.s3"
      STORAGE_PRIVATE_SOURCE: "private.storage.s3"
      STORAGE_ENDPOINT: "http://minio:9000"
      STORAGE_PUBLIC_BUCKET: "$STORAGE_PUBLIC_BUCKET"
      STORAGE_PRIVATE_BUCKET: "$STORAGE_PRIVATE_BUCKET"
      STORAGE_ACCESS_KEY: "$STORAGE_ACCESS_KEY"
      STORAGE_SECRET_KEY: "$STORAGE_SECRET_KEY"
      # i18n.
      DEFAULT_LOCALE: "$DEFAULT_LOCALE"
      # Mailer.
      MAILER_DSN: "smtp://null:null@mailhog:1025"
      MAIL_FROM_ADDRESS: "no variable is not set. Defaulting to a blank string. 
```
after that it runs the container
```
+] Running 10/10
 ⠿ Network symfony-boilerplate_default          Created                                                                                        0.3s
 ⠿ Container symfony-boilerplate_mysql_1        Started                                                                                        4.8s
 ⠿ Container symfony-boilerplate_mysql_tests_1  Started                                                                                        4.7s
 ⠿ Container symfony-boilerplate_api_1          Started                                                                                        5.6s
 ⠿ Container symfony-boilerplate_minio_1        Started                                                                                        5.6s
 ⠿ Container symfony-boilerplate_phpmyadmin_1   Started                                                                                        5.4s
 ⠿ Container symfony-boilerplate_redis_1        Started                                                                                        5.7s
 ⠿ Container symfony-boilerplate_mailhog_1      Started                                                                                        5.6s
 ⠿ Container symfony-boilerplate_webapp_1       Started                                                                                        2.9s
 ⠿ Container symfony-boilerplate_traefik_1      Started                                                                                        5.7s
```
However, the API container will stop eventually and the webapp would fall into NUXT error page complain about could not get feedback from API.

# resolution
After some investigation, I found that the statement of retrieving environmental variables in docker-compose.yml are like so `"xxx$var"` which isn't the format for the latest version `xxx${var}`. 

this pull request is just changing all the `xxx$var` to `xxx${var}` inside docker-compose.yml for a smooth start of the boilerplate on macOS Big Sur ver 11.5.1