### PR TITLE
Fix - CORS allowing undesired origins

### DIFF
--- a/src/api/config/packages/nelmio_cors.yaml
+++ b/src/api/config/packages/nelmio_cors.yaml
@@ -1,7 +1,6 @@
 nelmio_cors:
     defaults:
         allow_credentials: true
-        origin_regex: true
         allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
         allow_headers: ['Content-Type', 'Authorization']


### PR DESCRIPTION
Regex mode allowed undesired domains to perform cross-origin requests, by simply satisfying the regex corresponding to the authorized origin.
For instance, if the authorized origin (i.e. the web app) was <ins>`https://my.website.com`</ins>, cross-origin requests could be sent from <ins>`https://my.website.com.mischievo.us`</ins>, or even <ins>`https://myawebsite.com`</ins>.