### PR TITLE
:bug: Fix image name when building with buildx

### DIFF
--- a/gitlab-ci/templates/build.gitlab-ci.yml
+++ b/gitlab-ci/templates/build.gitlab-ci.yml
@@ -48,11 +48,9 @@
          --cache-from ${IMAGE_DESTINATION}:latest
          --build-arg BUILDKIT_INLINE_CACHE=1
          -t $IMAGE_DESTINATION
-         -t ${IMAGE_DESTINATION}:latest
          --target=${TARGET}
       '
     - docker push ${IMAGE_DESTINATION}
-    - docker push ${IMAGE_DESTINATION}:latest
 
 .build image:
   extends:


### PR DESCRIPTION
We cannot use the `:latest` prefix as this will generate a name like `my.registry.com/my-image:my-branch:latest`, notice there are "2" tags: `my-branch` and `latest` which is wrong.